### PR TITLE
Made socket.request callback backwards compatible

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -335,7 +335,14 @@
         data: options.data,
         url: options.url,
         headers: options.headers,
-        cb: cb
+        // Callback arguments are (body, response)
+        cb: function(data) {
+          if (data.body) {
+            cb(data.body, data);
+          } else {
+            cb(data);
+          }
+        }
       };
 
       // If this socket is not connected yet, queue up this request


### PR DESCRIPTION
By having the first argument contain just the response body, and the second contain the full response (with status, headers, etc), the new version is completely backwards compatible and reminiscent of the Node Request module...
