### PR TITLE
Added public request method as per documentation

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -436,7 +436,7 @@
       }
 
       return this._request({
-          method: method || '',
+          method: method || 'get',
           data: data,
           url: url
       }, cb);


### PR DESCRIPTION
Hi,

I noticed that the public request method hadn't been added, but was included in the v0.10 SocketClient docs - I've added it in this commit.

Cheers
