### PR TITLE
Check hasOwnProperty when iteration over keys on an array.

### DIFF
--- a/dist/sails.io.js
+++ b/dist/sails.io.js
@@ -660,10 +660,12 @@ var io="undefined"==typeof module?{}:module.exports;(function(){(function(a,b){v
             var pendingRequestsForSocket = requestQueues[socketId];
 
             for (var i in pendingRequestsForSocket) {
-              var pendingRequest = pendingRequestsForSocket[i];
+              if (({}).hasOwnProperty.call(pendingRequestsForSocket, i)) {
+                var pendingRequest = pendingRequestsForSocket[i];
 
-              // Emit the request.
-              _emitFrom(sockets[socketId], pendingRequest);
+                // Emit the request.
+                _emitFrom(sockets[socketId], pendingRequest);
+              }
             }
           }
 

--- a/sails.io.js
+++ b/sails.io.js
@@ -657,10 +657,12 @@
             var pendingRequestsForSocket = requestQueues[socketId];
 
             for (var i in pendingRequestsForSocket) {
-              var pendingRequest = pendingRequestsForSocket[i];
+              if (({}).hasOwnProperty.call(pendingRequestsForSocket, i)) {
+                var pendingRequest = pendingRequestsForSocket[i];
 
-              // Emit the request.
-              _emitFrom(sockets[socketId], pendingRequest);
+                // Emit the request.
+                _emitFrom(sockets[socketId], pendingRequest);
+              }
             }
           }
 


### PR DESCRIPTION
Hello. I ran into an error when using Ember.js with Sails. By default, Ember.js extends the array prototype to add some connivence methods to arrays which make them easier to work with in Ember. Unfortunately these properties show up as keys when iteration over an array using the `(key in array)` syntax. This pr checks if the key is on the array before using it to retrieve a value from the array.
