### PR TITLE
Issue with 'delete' reserved word in IE8

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -118,7 +118,7 @@
       this.get = Socket.prototype.get;
       this.post = Socket.prototype.post;
       this.put = Socket.prototype.put;
-      this.delete = Socket.prototype.delete;
+      this['delete'] = Socket.prototype['delete'];
       this._request = Socket.prototype._request;
     }
 


### PR DESCRIPTION
There is an issue with using `delete` for object property names in IE8. It will throw an error saying `Expected Identifier`.

I made some changes to make any object `delete` properties use the bracket notation instead of dot notation as that will take care of the issue for the time being.

I would suggest maybe change the property names to something other than delete going forward though, as it is not very pleasant to have to write `socket['delete']`. Maybe `remove` as a property name would be better?
