### PR TITLE
Attach the SailsIOclient to the global object

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -807,8 +807,9 @@
     module.exports = SailsIOClient;
     return SailsIOClient;
   }
-
-  // Attach the sails client to the global object
-  window.SailsIOClient = SailsIOClient;
+  else {
+    // Attach the sails client to the global object
+    window.SailsIOClient = SailsIOClient;
+  }
 
 })();


### PR DESCRIPTION
By doing that we let the user total control of the life cycle of the client connection.

If we need to click a button "connect" on a UI to create the connection as example.
