### PR TITLE
Fix for requestQueue not working

### DIFF
--- a/dist/sails.io.js
+++ b/dist/sails.io.js
@@ -124,7 +124,6 @@ var io="undefined"==typeof module?{}:module.exports;(function(){(function(a,b){v
             actualSocket.on(evName, boundEvents[evName][i]);
           }
         }
-        actualSocket.requestQueue = this.requestQueue;
 
         // Bind a one-time function to run the request queue
         // when the actualSocket connects.


### PR DESCRIPTION
I noticed the requestQueue was not getting processed in my demo app. Some debugging revealed `actualSocket.requestQueue` contained the actual list of pending requests, and `this.requestQueue` was always undefined, since `this` points at `function TmpSocket()`.

Removing this line in my code fixed the problem, so I figured I'd send it along.