### PR TITLE
Prevent Browserify from breaking

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -671,7 +671,7 @@
         // so just require the request module and send the HTTP request that
         // way.
         else {
-          var mikealsReq = GLOBAL['require']('request');
+          var mikealsReq = this['require']('request');
           mikealsReq.get(io.sails.url + xOriginCookieRoute, function(err, httpResponse, body) {
             if (err) {
               consolog(

--- a/sails.io.js
+++ b/sails.io.js
@@ -671,7 +671,7 @@
         // so just require the request module and send the HTTP request that
         // way.
         else {
-          var mikealsReq = require('request');
+          var mikealsReq = GLOBAL['require']('request');
           mikealsReq.get(io.sails.url + xOriginCookieRoute, function(err, httpResponse, body) {
             if (err) {
               consolog(


### PR DESCRIPTION
Previously I was unable to include sails.io via Browserify, due to the request module being require'd (even though it would never be used in the browser). So, here's a fix that keeps it working in Node while keeping Browserify from picking up on it and breaking, by pulling it verbosely from Node's `GLOBAL`.

Aaand this worked locally but travis seems to dislike it. Looking into it...