### PR TITLE
Allow sending headers with socket-based requests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ results
 npm-debug.log
 node_modules
 
-
+.idea
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "sails.io.js",
   "main": "dist/sails.io.js",
-  "version": "v0.10.1",
+  "version": "v0.10.3",
   "homepage": "https://github.com/balderdashy/sails.io.js",
   "authors": [
     "Mike McNeil <mike@balderdash.co>"

--- a/dist/sails.io.js
+++ b/dist/sails.io.js
@@ -529,6 +529,12 @@ var io="undefined"==typeof module?{}:module.exports;(function(){(function(a,b){v
         (options.method || 'request') +
         '( destinationURL, [dataToSend], [fnToCallWhenComplete] )';
 
+      // Move headers out of data if they exist
+      if (options.data && options.data.headers) {
+        options.headers = options.data.headers;
+        delete options.data.headers;
+      }
+
       options = options || {};
       options.data = options.data || {};
       options.headers = options.headers || {};

--- a/sails.io.js
+++ b/sails.io.js
@@ -526,6 +526,12 @@
         (options.method || 'request') +
         '( destinationURL, [dataToSend], [fnToCallWhenComplete] )';
 
+      // Move headers out of data if they exist
+      if (options.data && options.data.headers) {
+        options.headers = options.data.headers;
+        delete options.data.headers;
+      }
+
       options = options || {};
       options.data = options.data || {};
       options.headers = options.headers || {};


### PR DESCRIPTION
We use header-based authentication to pass our policies. With the update from Sails 0.10.1 to 0.10.4, the client library changed and our policies were denying socket-based requests. This PR restores the ability to set headers for websocket requests.

Relevant issue: https://github.com/balderdashy/sails/issues/2041