### PR TITLE
isXOrigin

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -641,7 +641,7 @@
       // socket connection, send a JSONP request first to ensure
       // that a valid cookie is available.  This can be disabled
       // by setting `io.sails.useCORSRouteToGetCookie` to false.
-      var isXOrigin = io.sails.url.replace(/^[a-z]+:\/\//i, '').search(location.hostname) !== 0;
+      var isXOrigin = typeof io.sails.url === 'string' && io.sails.url.replace(/^[a-z]+:\/\//i, '').search(location.hostname) !== 0;
 
       // var port = global.location.port || ('https:' == global.location.protocol ? 443 : 80);
       // this.options.host !== global.location.hostname || this.options.port != port;


### PR DESCRIPTION
Simple. The hostname is _just_ the hostname. No ports, no protocol.. So no matter what is in io.sails.url, it must contain location.hostname.

``` javascript
location.hostname;
// > "api.islive.io"

'islive.io'.search(location.hostname) === -1;
// > true

'api.islive.io'.search(location.hostname) === -1;
// > false

'http://api.islive.io/namespace'.search(location.hostname) === -1;
// > false
```
