### PR TITLE
Update bower.json to reflect new tag

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "sails.io.js",
   "main": "dist/sails.io.js",
-  "version": "v0.10.1",
+  "version": "v0.10.3",
   "homepage": "https://github.com/balderdashy/sails.io.js",
   "authors": [
     "Mike McNeil <mike@balderdash.co>"


### PR DESCRIPTION
Installing sails.io.js in bower produces an error because the tag doesn't match the bower.json version.

```
$ bower install -S sails.io.js
bower cached        git://github.com/balderdashy/sails.io.js.git#0.10.0-rc2
bower validate      0.10.0-rc2 against git://github.com/balderdashy/sails.io.js.git#*
bower new           version for git://github.com/balderdashy/sails.io.js.git#*
bower resolve       git://github.com/balderdashy/sails.io.js.git#*
bower download      https://github.com/balderdashy/sails.io.js/archive/v0.10.3.tar.gz
bower extract       sails.io.js#* archive.tar.gz
bower mismatch      Version declared in the json (v0.10.1) is different than the resolved one (0.10.3)
bower resolved      git://github.com/balderdashy/sails.io.js.git#0.10.3
bower ECONFLICT     Unable to find suitable version for sails.io.js
```
