### PR TITLE
fix for requestQueue when re-connecting

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -174,7 +174,7 @@
       }
 
       // Now empty the queue to remove it as a source of additional complexity.
-      queue = null;
+      socket.requestQueue = null;
     }
 
 
@@ -618,11 +618,8 @@
       // Bind a one-time function to run the request queue
       // when the self._raw connects.
       if ( !self.isConnected() ) {
-        var alreadyRanRequestQueue = false;
         self._raw.on('connect', function whenRawSocketConnects() {
-          if (alreadyRanRequestQueue) return;
           runRequestQueue(self);
-          alreadyRanRequestQueue = true;
         });
       }
       // Or run it immediately if self._raw is already connected


### PR DESCRIPTION
When making calls during a disconnected state, they were being lost in the requestQueue if it was any time after the initial launch of the app. This change fixes that.

I tried to make a unit test for it but I couldn't figure out how to reliably simulate a sails.lower and sails.lift again so the test would reconnect.