### PR TITLE
Move request queue replays

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -479,15 +479,14 @@
         // using Socket.io and save it as `_raw` (this will start it connecting)
         self._raw = io(self.url, self);
 
-        // Replay event bindings from the eager socket
-        self.replay();
-
-
         /**
          * 'connect' event is triggered when the socket establishes a connection
          *  successfully.
          */
         self.on('connect', function socketConnected() {
+
+          // Replay event bindings from the eager socket
+          self.replay();
 
           consolog.noPrefix(
             '\n' +


### PR DESCRIPTION
Previously replays were attempted to be run before the socket connected, and were not run at all when a socket disconnected and reconnected this fixes that.