### PR TITLE
Fixed query parameters (includes query test and dist file update)

### DIFF
--- a/dist/sails.io.js
+++ b/dist/sails.io.js
@@ -327,6 +327,7 @@ var parts=["source","protocol","authority","userInfo","user","password","host","
       self.url = opts.url;
       self.multiplex = opts.multiplex;
       self.transports = opts.transports;
+      self.query = opts.query;
 
       // Set up "eventQueue" to hold event handlers which have not been set on the actual raw socket yet.
       self.eventQueue = {};
@@ -361,6 +362,7 @@ var parts=["source","protocol","authority","userInfo","user","password","host","
       self.useCORSRouteToGetCookie = self.useCORSRouteToGetCookie||io.sails.useCORSRouteToGetCookie;
       self.url = self.url||io.sails.url;
       self.transports = self.transports || io.sails.transports;
+      self.query = self.query || io.sails.query;
 
       // Ensure URL has no trailing slash
       self.url = self.url ? self.url.replace(/(\/)$/, '') : undefined;

--- a/sails.io.js
+++ b/sails.io.js
@@ -320,6 +320,7 @@
       self.url = opts.url;
       self.multiplex = opts.multiplex;
       self.transports = opts.transports;
+      self.query = opts.query;
 
       // Set up "eventQueue" to hold event handlers which have not been set on the actual raw socket yet.
       self.eventQueue = {};
@@ -354,6 +355,7 @@
       self.useCORSRouteToGetCookie = self.useCORSRouteToGetCookie||io.sails.useCORSRouteToGetCookie;
       self.url = self.url||io.sails.url;
       self.transports = self.transports || io.sails.transports;
+      self.query = self.query || io.sails.query;
 
       // Ensure URL has no trailing slash
       self.url = self.url ? self.url.replace(/(\/)$/, '') : undefined;

--- a/test/helpers/lifecycle.js
+++ b/test/helpers/lifecycle.js
@@ -69,6 +69,10 @@ module.exports = {
         io.sails.useCORSRouteToGetCookie = opts.useCORSRouteToGetCookie;
       }
 
+      if (typeof (opts.query) != 'undefined') {
+        io.sails.query = opts.query;
+      }
+
       // Globalize sails app as `server`
       global.server = app;
 

--- a/test/helpers/setupRoutes.js
+++ b/test/helpers/setupRoutes.js
@@ -4,8 +4,14 @@
 
 var _  = require('lodash');
 
+//Helper function we use to do a lookup on an object.
+//It splits the dot string to an object path.
 
-
+function _dotToObject(obj, path) {
+  return path.split('.').reduce(function objectIndex(obj, i) {
+    return obj[i]
+  }, obj);
+}
 
 /**
  * @return {Function} configured and ready to use by mocha's `before()`
@@ -23,7 +29,7 @@ module.exports = function setupRoutes (expectedResponses) {
     _.each(expectedResponses, function (expectedResponse, routeAddress) {
       sails.router.bind(routeAddress, function (req, res) {
         // console.log('\n------ calling res.send(%s, "%s")', expectedResponse.statusCode || 200, expectedResponse.body);
-        return res.send(expectedResponse.statusCode || 200, expectedResponse.body);
+        return res.send(expectedResponse.statusCode || 200, expectedResponse.req && _dotToObject(req, expectedResponse.req) || expectedResponse.body);
       });
     });
   };

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,0 +1,62 @@
+/**
+ * Module dependencies
+ */
+
+var util = require('util');
+var assert = require('assert');
+var lifecycle = require('./helpers/lifecycle');
+var _setupRoutes = require('./helpers/setupRoutes');
+var _assertResponse = function ( expectedResponses ) {
+  return function (routeAddress, callbackArgs) {
+    var body = callbackArgs[0];
+    var jwr = callbackArgs[1];
+
+    // Ensure JWR is valid
+    assert.equal(typeof jwr, 'object');
+
+    // Ensure body's type is correct
+    assert.equal((typeof body),(typeof expectedResponses[routeAddress].body), util.format('Expecting type:%s:\n%s\n\nbut got type:%s:\n%s\n', (typeof expectedResponses[routeAddress].body), util.inspect(expectedResponses[routeAddress].body, false, null), (typeof body),util.inspect(body,false,null)));
+
+    // Ensure body is the correct value
+    assert.deepEqual(expectedResponses[routeAddress].body, body);
+
+    // Ensure jwr's statusCode is correct
+    assert.deepEqual(expectedResponses[routeAddress].statusCode || 200, jwr.statusCode);
+  };
+};
+
+var EXPECTED_RESPONSES = {
+  'post /auth': { req: 'socket.handshake.query.token', body: '290891' }
+};
+
+var setupRoutes = _setupRoutes(EXPECTED_RESPONSES);
+var assertResponse = _assertResponse(EXPECTED_RESPONSES);
+
+
+describe('io.socket', function () {
+
+  describe('With query settings', function() {
+    before(function(done) {
+      lifecycle.setup({transports: ['websocket'], query: 'token=290891'}, function() {
+        done();
+      });
+    });
+    before(setupRoutes);
+
+    describe('once connected, socket', function () {
+
+      it('should be able to send a query parameter and receive the expected query in the request', function (cb) {
+        io.socket.post('/auth', {}, function (body, jwr) {
+          assertResponse('post /auth', arguments);
+          return cb();
+        });
+      });
+
+    });
+
+
+    after(lifecycle.teardown);
+    
+  });
+
+});


### PR DESCRIPTION
Hey,

This PR is based on the one by @weblogixx #46, without the formatting mess up that was included in that PR. With slight non-breaking changes to the helpers, this includes the test spec for query parameters which passes all tests (11 now). The dist sails.io.js file has also been updated using grunt. 

Awaiting this PR (https://github.com/Automattic/socket.io/pull/2051) to be accepted to write the test for initial handshake with query parameters on beforeConnect().

Thanks.