### PR TITLE
add options io.sails.path to configure url of socket.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 
 
 
+/.project

--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ $ bower install sails.io.js
 
 ###### Cross-domain
 
-Connect to a server other than the one that served ths project (i.e. on a different domain/subdomain):
+Connect to a server other than the one that served ths project (i.e. on a different domain/subdomain or path):
 
 ```html
 <script type="text/javascript" src="./path/to/bower_components/sails.io.js"></script>
 <script type="text/javascript">
 io.sails.url = 'https://api.mysite.com';
+io.sails.path = '/im.v1/socket.io';
 </script>
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "sails.io.js",
   "main": "dist/sails.io.js",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "homepage": "https://github.com/balderdashy/sails.io.js",
   "authors": [
     "Mike McNeil <mike@balderdash.co>"

--- a/dist/sails.io.js
+++ b/dist/sails.io.js
@@ -371,6 +371,7 @@ var parts=["source","protocol","authority","userInfo","user","password","host","
       // (now that at least one tick has elapsed)
       self.useCORSRouteToGetCookie = self.useCORSRouteToGetCookie||io.sails.useCORSRouteToGetCookie;
       self.url = self.url||io.sails.url;
+      self.path = self.path||io.sails.path||'/socket.io';
       self.transports = self.transports || io.sails.transports;
 
       // Ensure URL has no trailing slash

--- a/sails.io.js
+++ b/sails.io.js
@@ -353,6 +353,7 @@
       // (now that at least one tick has elapsed)
       self.useCORSRouteToGetCookie = self.useCORSRouteToGetCookie||io.sails.useCORSRouteToGetCookie;
       self.url = self.url||io.sails.url;
+      self.path = self.path||io.sails.path||'/socket.io';
       self.transports = self.transports || io.sails.transports;
 
       // Ensure URL has no trailing slash


### PR DESCRIPTION
The options io.sails.path is to allow user changing the url of socket.io server endpoint. For example, http://localhost:3000/im.v1/socket.io instead of default http://localhost:3000/socket.io. Please review.