### PR TITLE
Fixed up the delete method for sails.io.js

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -798,7 +798,7 @@
      * @param {Function} cb   ::    callback function to call when finished [optional]
      */
 
-    SailsSocket.prototype['delete'] = function(url, data, cb) {
+    SailsSocket.prototype.del = function(url, data, cb) {
 
       // `data` is optional
       if (typeof data === 'function') {


### PR DESCRIPTION
Fixed up the delete method, so we can use delete in the websocket connection's. 

I used .del since delete it a reserved work in JS, and most libraries i have seen use ".del" 