### PR TITLE
add path options

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -356,6 +356,7 @@
       self.url = self.url||io.sails.url;
       self.transports = self.transports || io.sails.transports;
       self.query = self.query || io.sails.query;
+      self.path = io.sails.path;
 
       // Ensure URL has no trailing slash
       self.url = self.url ? self.url.replace(/(\/)$/, '') : undefined;


### PR DESCRIPTION
For http://stackoverflow.com/questions/29511404/connect-to-socket-io-server-with-specific-path-and-namespace situation.

**Usage**

```
io.sails.url = "http://www.example.com"
io.sails.path = "/myapp/socket.io"
io.sails.useCORSRouteToGetCookie = "/myapp/__getcookie"
```