### PR TITLE
Added path param

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -360,6 +360,7 @@
       // (now that at least one tick has elapsed)
       self.useCORSRouteToGetCookie = self.useCORSRouteToGetCookie||io.sails.useCORSRouteToGetCookie;
       self.url = self.url||io.sails.url;
+      self.path = self.path||io.sails.path;
       self.transports = self.transports || io.sails.transports;
       self.query = self.query || io.sails.query;
       // Global headers that will be sent with every io.socket request


### PR DESCRIPTION
socket.io defaults to /socket.io path. This MR provides a way to override this