### PR TITLE
removes data when cloning data into params.

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -937,6 +937,7 @@
       }
       else if (options.data) {
         options.params = options.data;
+        delete options.data;
       }
 
 


### PR DESCRIPTION
If params are passed on the first call, once it resends the request
both data and params exists. This fix removes data, so that it does not
fail the validation