### PR TITLE
Support for setting `io.sails` config using HTML attributes on the <script> tag that brought in the library.

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -1249,11 +1249,11 @@
     module.exports = SailsIOClient;
     return SailsIOClient;
   }
+  // Add AMD support, registering this client SDK as an anonymous module.
   else if (typeof define === 'function' && define.amd) {
-      // AMD. Register as an anonymous module.
-      define([], function() {
-        return SailsIOClient;
-      });
+    define([], function() {
+      return SailsIOClient;
+    });
   }
   else {
     // Otherwise, try to instantiate the client:

--- a/sails.io.js
+++ b/sails.io.js
@@ -108,13 +108,19 @@
 
 
 
-
-  //   ██████╗ ██████╗  █████╗ ██████╗     ██╗ ██████╗    ███████╗ █████╗ ██╗██╗     ███████╗
-  //  ██╔════╝ ██╔══██╗██╔══██╗██╔══██╗    ██║██╔═══██╗   ██╔════╝██╔══██╗██║██║     ██╔════╝ ▄ ██╗▄
-  //  ██║  ███╗██████╔╝███████║██████╔╝    ██║██║   ██║   ███████╗███████║██║██║     ███████╗  ████╗
-  //  ██║   ██║██╔══██╗██╔══██║██╔══██╗    ██║██║   ██║   ╚════██║██╔══██║██║██║     ╚════██║ ▀╚██╔▀
-  //  ╚██████╔╝██║  ██║██║  ██║██████╔╝    ██║╚██████╔╝██╗███████║██║  ██║██║███████╗███████║██╗╚═╝
-  //   ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝     ╚═╝ ╚═════╝ ╚═╝╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚═╝
+  //   █████╗ ██████╗ ███████╗ ██████╗ ██████╗ ██████╗     ██╗  ██╗████████╗███╗   ███╗██╗
+  //  ██╔══██╗██╔══██╗██╔════╝██╔═══██╗██╔══██╗██╔══██╗    ██║  ██║╚══██╔══╝████╗ ████║██║
+  //  ███████║██████╔╝███████╗██║   ██║██████╔╝██████╔╝    ███████║   ██║   ██╔████╔██║██║
+  //  ██╔══██║██╔══██╗╚════██║██║   ██║██╔══██╗██╔══██╗    ██╔══██║   ██║   ██║╚██╔╝██║██║
+  //  ██║  ██║██████╔╝███████║╚██████╔╝██║  ██║██████╔╝    ██║  ██║   ██║   ██║ ╚═╝ ██║███████╗
+  //  ╚═╝  ╚═╝╚═════╝ ╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═════╝     ╚═╝  ╚═╝   ╚═╝   ╚═╝     ╚═╝╚══════╝
+  //
+  //   █████╗ ████████╗████████╗██████╗ ██╗██████╗ ██╗   ██╗████████╗███████╗███████╗
+  //  ██╔══██╗╚══██╔══╝╚══██╔══╝██╔══██╗██║██╔══██╗██║   ██║╚══██╔══╝██╔════╝██╔════╝
+  //  ███████║   ██║      ██║   ██████╔╝██║██████╔╝██║   ██║   ██║   █████╗  ███████╗
+  //  ██╔══██║   ██║      ██║   ██╔══██╗██║██╔══██╗██║   ██║   ██║   ██╔══╝  ╚════██║
+  //  ██║  ██║   ██║      ██║   ██║  ██║██║██████╔╝╚██████╔╝   ██║   ███████╗███████║
+  //  ╚═╝  ╚═╝   ╚═╝      ╚═╝   ╚═╝  ╚═╝╚═╝╚═════╝  ╚═════╝    ╚═╝   ╚══════╝╚══════╝
   //
   //  ███████╗██████╗  ██████╗ ███╗   ███╗      ██╗███████╗ ██████╗██████╗ ██╗██████╗ ████████╗██╗
   //  ██╔════╝██╔══██╗██╔═══██╗████╗ ████║     ██╔╝██╔════╝██╔════╝██╔══██╗██║██╔══██╗╚══██╔══╝╚██╗
@@ -123,14 +129,6 @@
   //  ██║     ██║  ██║╚██████╔╝██║ ╚═╝ ██║     ╚██╗███████║╚██████╗██║  ██║██║██║        ██║   ██╔╝
   //  ╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═╝     ╚═╝      ╚═╝╚══════╝ ╚═════╝╚═╝  ╚═╝╚═╝╚═╝        ╚═╝   ╚═╝
   //
-  //  ██╗  ██╗████████╗███╗   ███╗██╗          █████╗ ████████╗████████╗██████╗ ███████╗
-  //  ██║  ██║╚══██╔══╝████╗ ████║██║         ██╔══██╗╚══██╔══╝╚══██╔══╝██╔══██╗██╔════╝
-  //  ███████║   ██║   ██╔████╔██║██║         ███████║   ██║      ██║   ██████╔╝███████╗
-  //  ██╔══██║   ██║   ██║╚██╔╝██║██║         ██╔══██║   ██║      ██║   ██╔══██╗╚════██║
-  //  ██║  ██║   ██║   ██║ ╚═╝ ██║███████╗    ██║  ██║   ██║      ██║   ██║  ██║███████║
-  //  ╚═╝  ╚═╝   ╚═╝   ╚═╝     ╚═╝╚══════╝    ╚═╝  ╚═╝   ╚═╝      ╚═╝   ╚═╝  ╚═╝╚══════╝
-  //
-
 
   // Save the URL that this script was fetched from, and any other config provided
   // as HTML attributes on the script tag.  This is used below.
@@ -232,24 +230,51 @@
 
 
 
-  // In case you're wrapping the socket.io client to prevent pollution of the
-  // global namespace, you can pass in your own `io` to replace the global one.
-  // But we still grab access to the global one if it's available here:
-  var _existingGlobalSocketIO = (typeof io !== 'undefined') ? io : null;
+  // Grab a reference to the global socket.io client (if one is available).
+  var _existingGlobalSocketIO = (typeof io !== 'undefined') ? io : undefined;
+
+
+
+
+
+
+
+  //  ███████╗ █████╗ ██╗██╗     ███████╗      ██╗ ██████╗        ██████╗██╗     ██╗███████╗███╗   ██╗████████╗
+  //  ██╔════╝██╔══██╗██║██║     ██╔════╝      ██║██╔═══██╗      ██╔════╝██║     ██║██╔════╝████╗  ██║╚══██╔══╝
+  //  ███████╗███████║██║██║     ███████╗█████╗██║██║   ██║█████╗██║     ██║     ██║█████╗  ██╔██╗ ██║   ██║
+  //  ╚════██║██╔══██║██║██║     ╚════██║╚════╝██║██║   ██║╚════╝██║     ██║     ██║██╔══╝  ██║╚██╗██║   ██║
+  //  ███████║██║  ██║██║███████╗███████║      ██║╚██████╔╝      ╚██████╗███████╗██║███████╗██║ ╚████║   ██║
+  //  ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝      ╚═╝ ╚═════╝        ╚═════╝╚══════╝╚═╝╚══════╝╚═╝  ╚═══╝   ╚═╝
+  //
 
   /**
-   * Augment the `io` object passed in with methods for talking and listening
-   * to one or more Sails backend(s).  Automatically connects a socket and
-   * exposes it on `io.socket`.  If a socket tries to make requests before it
-   * is connected, the sails.io.js client will queue it up.
+   * SailsIOClient()
+   *
+   * Augment the provided Socket.io client object (`io`) with methods for
+   * talking and listening to one or more Sails backend(s).  If no `io` was
+   * provided (i.e. in a browser setting), then attempt to use the global.
+   *
+   * This absorbs implicit `io.sails` configuration, sets a timer for
+   * automatically connecting a socket (if `io.sails.autoConnect` is enabled)
+   * and returns the augmented `io`.
+   *
+   * Note:
+   * The automatically-connected socket is exposed as `io.socket`.  If this
+   * socket attempts to bind event listeners or send requests before it is
+   * connected, it will be queued up and replayed when the connection is
+   * successfully opened.
    *
    * @param {SocketIO} io
+   * @returns {SailsIOClient} [also called `io`]
    */
 
-  function SailsIOClient(io) {
+  function SailsIOClient(_providedSocketIO) {
+
+    // First, determine which `io` we're augmenting.
+    var io;
 
     // Prefer the passed-in `io` instance, but fall back to the global one if we've got it.
-    if (!io) {
+    if (!_providedSocketIO) {
       io = _existingGlobalSocketIO;
     }
 
@@ -314,7 +339,7 @@
           .bind(console)
           .apply(this, args);
       };
-    }
+    }//</LoggerFactory>
 
     // Create a private logger instance
     var consolog = LoggerFactory();
@@ -389,6 +414,22 @@
 
 
 
+
+    //       ██╗███████╗ ██████╗ ███╗   ██╗      ██╗    ██╗███████╗██████╗ ███████╗ ██████╗  ██████╗██╗  ██╗███████╗████████╗
+    //       ██║██╔════╝██╔═══██╗████╗  ██║      ██║    ██║██╔════╝██╔══██╗██╔════╝██╔═══██╗██╔════╝██║ ██╔╝██╔════╝╚══██╔══╝
+    //       ██║███████╗██║   ██║██╔██╗ ██║█████╗██║ █╗ ██║█████╗  ██████╔╝███████╗██║   ██║██║     █████╔╝ █████╗     ██║
+    //  ██   ██║╚════██║██║   ██║██║╚██╗██║╚════╝██║███╗██║██╔══╝  ██╔══██╗╚════██║██║   ██║██║     ██╔═██╗ ██╔══╝     ██║
+    //  ╚█████╔╝███████║╚██████╔╝██║ ╚████║      ╚███╔███╔╝███████╗██████╔╝███████║╚██████╔╝╚██████╗██║  ██╗███████╗   ██║
+    //   ╚════╝ ╚══════╝ ╚═════╝ ╚═╝  ╚═══╝       ╚══╝╚══╝ ╚══════╝╚═════╝ ╚══════╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝╚══════╝   ╚═╝
+    //
+    //  ██████╗ ███████╗███████╗██████╗  ██████╗ ███╗   ██╗███████╗███████╗     ██╗     ██╗██╗    ██╗██████╗ ██╗
+    //  ██╔══██╗██╔════╝██╔════╝██╔══██╗██╔═══██╗████╗  ██║██╔════╝██╔════╝    ██╔╝     ██║██║    ██║██╔══██╗╚██╗
+    //  ██████╔╝█████╗  ███████╗██████╔╝██║   ██║██╔██╗ ██║███████╗█████╗      ██║      ██║██║ █╗ ██║██████╔╝ ██║
+    //  ██╔══██╗██╔══╝  ╚════██║██╔═══╝ ██║   ██║██║╚██╗██║╚════██║██╔══╝      ██║ ██   ██║██║███╗██║██╔══██╗ ██║
+    //  ██║  ██║███████╗███████║██║     ╚██████╔╝██║ ╚████║███████║███████╗    ╚██╗╚█████╔╝╚███╔███╔╝██║  ██║██╔╝
+    //  ╚═╝  ╚═╝╚══════╝╚══════╝╚═╝      ╚═════╝ ╚═╝  ╚═══╝╚══════╝╚══════╝     ╚═╝ ╚════╝  ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝
+    //
+
     /**
      * The JWR (JSON WebSocket Response) received from a Sails server.
      *
@@ -428,6 +469,16 @@
     };
 
 
+
+
+    //          ███████╗███╗   ███╗██╗████████╗███████╗██████╗  ██████╗ ███╗   ███╗ ██╗██╗
+    //          ██╔════╝████╗ ████║██║╚══██╔══╝██╔════╝██╔══██╗██╔═══██╗████╗ ████║██╔╝╚██╗
+    //          █████╗  ██╔████╔██║██║   ██║   █████╗  ██████╔╝██║   ██║██╔████╔██║██║  ██║
+    //          ██╔══╝  ██║╚██╔╝██║██║   ██║   ██╔══╝  ██╔══██╗██║   ██║██║╚██╔╝██║██║  ██║
+    //  ███████╗███████╗██║ ╚═╝ ██║██║   ██║   ██║     ██║  ██║╚██████╔╝██║ ╚═╝ ██║╚██╗██╔╝
+    //  ╚══════╝╚══════╝╚═╝     ╚═╝╚═╝   ╚═╝   ╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═╝     ╚═╝ ╚═╝╚═╝
+    //
+
     /**
      * @api private
      * @param  {SailsSocket} socket  [description]
@@ -458,26 +509,19 @@
       });
     }
 
-    //////////////////////////////////////////////////////////////
-    ///// </PRIVATE METHODS/CONSTRUCTORS> ////////////////////////
-    //////////////////////////////////////////////////////////////
 
 
 
-    // Version note:
+
+
+
+    //  ███████╗ █████╗ ██╗██╗     ███████╗███████╗ ██████╗  ██████╗██╗  ██╗███████╗████████╗
+    //  ██╔════╝██╔══██╗██║██║     ██╔════╝██╔════╝██╔═══██╗██╔════╝██║ ██╔╝██╔════╝╚══██╔══╝
+    //  ███████╗███████║██║██║     ███████╗███████╗██║   ██║██║     █████╔╝ █████╗     ██║
+    //  ╚════██║██╔══██║██║██║     ╚════██║╚════██║██║   ██║██║     ██╔═██╗ ██╔══╝     ██║
+    //  ███████║██║  ██║██║███████╗███████║███████║╚██████╔╝╚██████╗██║  ██╗███████╗   ██║
+    //  ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝╚══════╝   ╚═╝
     //
-    // `io.SocketNamespace.prototype` doesn't exist in sio 1.0.
-    //
-    // Rather than adding methods to the prototype for the Socket instance that is returned
-    // when the browser connects with `io.connect()`, we create our own constructor, `SailsSocket`.
-    // This makes our solution more future-proof and helps us work better w/ the Socket.io team
-    // when changes are rolled out in the future.  To get a `SailsSocket`, you can run:
-    // ```
-    // io.sails.connect();
-    // ```
-
-
-
 
     /**
      * SailsSocket
@@ -491,8 +535,16 @@
      * WHICH SERVER to talk to yet, etc.  It is also used by `io.socket` for your convenience.
      *
      * @constructor
+     * @api private
+     *
+     * ----------------------------------------------------------------------
+     * Note: This constructor should not be used directly. To obtain a `SailsSocket`
+     * instance of your very own, run:
+     * ```
+     * var mySocket = io.sails.connect();
+     * ```
+     * ----------------------------------------------------------------------
      */
-
     function SailsSocket (opts){
       var self = this;
       opts = opts||{};
@@ -548,11 +600,13 @@
       // However, note that the `console.log`s called before and after connection
       // are still forced to rely on our existing heuristics (to disable, tack #production
       // onto the URL used to fetch this file.)
-    }
+    }//</SailsSocket>
 
 
     /**
-     * Start connecting this socket.
+     * `SailsSocket.prototype._connect()`
+     *
+     * Begin connecting this socket to the server.
      *
      * @api private
      */
@@ -1181,16 +1235,26 @@
 
 
 
-    // Set a `sails` object that may be used for configuration before the
+
+
+
+
+    //  ██╗ ██████╗    ███████╗ █████╗ ██╗██╗     ███████╗
+    //  ██║██╔═══██╗   ██╔════╝██╔══██╗██║██║     ██╔════╝
+    //  ██║██║   ██║   ███████╗███████║██║██║     ███████╗
+    //  ██║██║   ██║   ╚════██║██╔══██║██║██║     ╚════██║
+    //  ██║╚██████╔╝██╗███████║██║  ██║██║███████╗███████║
+    //  ╚═╝ ╚═════╝ ╚═╝╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝
+    //
+    // Set an `io.sails` object that may be used for configuration before the
     // first socket connects (i.e. to allow auto-connect behavior to be
     // prevented by setting `io.sails.autoConnect` in an inline script
     // directly after the script tag which loaded this file).
-    //
-    //////////////////////////////////////////////////////////////////////////////
-    // Note that the new HTML attribute configuration style may eventually
-    // completely replace this original approach-- it is easier to reason
-    // about, and also it would allow us to remove timeout below.
-    //////////////////////////////////////////////////////////////////////////////
+
+
+    //  ┌─┐┌─┐┌┬┐  ┬ ┬┌─┐  ╔╦╗╔═╗╔═╗╔═╗╦ ╦╦ ╔╦╗╔═╗  ┌─┐┌─┐┬─┐  ┬┌─┐ ┌─┐┌─┐┬┬  ┌─┐
+    //  └─┐├┤  │   │ │├─┘   ║║║╣ ╠╣ ╠═╣║ ║║  ║ ╚═╗  ├┤ │ │├┬┘  ││ │ └─┐├─┤││  └─┐
+    //  └─┘└─┘ ┴   └─┘┴    ═╩╝╚═╝╚  ╩ ╩╚═╝╩═╝╩ ╚═╝  └  └─┘┴└─  ┴└─┘o└─┘┴ ┴┴┴─┘└─┘
     io.sails = {
 
       // Whether to automatically connect a socket and save it as `io.socket`.
@@ -1217,6 +1281,16 @@
 
 
 
+    //  ┌─┐─┐ ┬┌┬┐┌─┐┌┐┌┌┬┐  ┬┌─┐ ┌─┐┌─┐┬┬  ┌─┐  ┌┬┐┌─┐┌─┐┌─┐┬ ┬┬ ┌┬┐┌─┐
+    //  ├┤ ┌┴┬┘ │ ├┤ │││ ││  ││ │ └─┐├─┤││  └─┐   ││├┤ ├┤ ├─┤│ ││  │ └─┐
+    //  └─┘┴ └─ ┴ └─┘┘└┘─┴┘  ┴└─┘o└─┘┴ ┴┴┴─┘└─┘  ─┴┘└─┘└  ┴ ┴└─┘┴─┘┴ └─┘
+    //  ┬ ┬┬┌┬┐┬ ┬  ┌┬┐┬ ┬┌─┐  ╦ ╦╔╦╗╔╦╗╦    ╔═╗╔╦╗╔╦╗╦═╗╦╔╗ ╦ ╦╔╦╗╔═╗╔═╗
+    //  ││││ │ ├─┤   │ ├─┤├┤   ╠═╣ ║ ║║║║    ╠═╣ ║  ║ ╠╦╝║╠╩╗║ ║ ║ ║╣ ╚═╗
+    //  └┴┘┴ ┴ ┴ ┴   ┴ ┴ ┴└─┘  ╩ ╩ ╩ ╩ ╩╩═╝  ╩ ╩ ╩  ╩ ╩╚═╩╚═╝╚═╝ ╩ ╚═╝╚═╝
+    //  ┌─┐┬─┐┌─┐┌┬┐  ┌┬┐┬ ┬┌─┐  ┌─┐┌─┐┬─┐┬┌─┐┌┬┐  ┌┬┐┌─┐┌─┐
+    //  ├┤ ├┬┘│ ││││   │ ├─┤├┤   └─┐│  ├┬┘│├─┘ │    │ ├─┤│ ┬
+    //  └  ┴└─└─┘┴ ┴   ┴ ┴ ┴└─┘  └─┘└─┘┴└─┴┴   ┴    ┴ ┴ ┴└─┘
+    //
     // Now fold in config provided as HTML attributes on the script tag:
     // (note that if `io.sails.*` is changed after this script, those changes
     //  will still take precedence)
@@ -1225,8 +1299,19 @@
         io.sails[htmlAttrName] = scriptTagConfig[htmlAttrName];
       }
     });
+    //////////////////////////////////////////////////////////////////////////////
+    // Note that the new HTML attribute configuration style may eventually
+    // completely replace the original approach of setting `io.sails` properties,
+    // since the new strategy is easier to reason about.  Also, it would allow us
+    // to remove the timeout below someday.
+    //////////////////////////////////////////////////////////////////////////////
 
 
+
+
+    //  ┬┌─┐ ┌─┐┌─┐┬┬  ┌─┐ ╔═╗╔═╗╔╗╔╔╗╔╔═╗╔═╗╔╦╗  /  \
+    //  ││ │ └─┐├─┤││  └─┐ ║  ║ ║║║║║║║║╣ ║   ║  /   /
+    //  ┴└─┘o└─┘┴ ┴┴┴─┘└─┘o╚═╝╚═╝╝╚╝╝╚╝╚═╝╚═╝ ╩  \  /
 
     /**
      * Add `io.sails.connect` function as a wrapper for the built-in `io()` aka `io.connect()`
@@ -1260,6 +1345,16 @@
 
 
 
+
+
+
+    //  ██╗ ██████╗    ███████╗ ██████╗  ██████╗██╗  ██╗███████╗████████╗
+    //  ██║██╔═══██╗   ██╔════╝██╔═══██╗██╔════╝██║ ██╔╝██╔════╝╚══██╔══╝
+    //  ██║██║   ██║   ███████╗██║   ██║██║     █████╔╝ █████╗     ██║
+    //  ██║██║   ██║   ╚════██║██║   ██║██║     ██╔═██╗ ██╔══╝     ██║
+    //  ██║╚██████╔╝██╗███████║╚██████╔╝╚██████╗██║  ██╗███████╗   ██║
+    //  ╚═╝ ╚═════╝ ╚═╝╚══════╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝╚══════╝   ╚═╝
+    //
     // io.socket
     //
     // The eager instance of Socket which will automatically try to connect
@@ -1271,13 +1366,19 @@
 
 
     // Build `io.socket` so it exists
-    // (this does not start the connection process)
+    // (note that this DOES NOT start the connection process)
     io.socket = new SailsSocket();
-
-    // In the mean time, this eager socket will be queue events bound by the user
+    //
+    // This socket is not connected yet, and has not even _started_ connecting.
+    //
+    // But in the mean time, this eager socket will be queue events bound by the user
     // before the first cycle of the event loop (using `.on()`), which will later
     // be rebound on the raw underlying socket.
 
+
+    //  ┌─┐┌─┐┌┬┐  ┌─┐┬ ┬┌┬┐┌─┐   ┌─┐┌─┐┌┐┌┌┐┌┌─┐┌─┐┌┬┐  ┌┬┐┬┌┬┐┌─┐┬─┐
+    //  └─┐├┤  │   ├─┤│ │ │ │ │───│  │ │││││││├┤ │   │    │ ││││├┤ ├┬┘
+    //  └─┘└─┘ ┴   ┴ ┴└─┘ ┴ └─┘   └─┘└─┘┘└┘┘└┘└─┘└─┘ ┴    ┴ ┴┴ ┴└─┘┴└─
     // If configured to do so, start auto-connecting after the first cycle of the event loop
     // has completed (to allow time for this behavior to be configured/disabled
     // by specifying properties on `io.sails`)
@@ -1301,10 +1402,21 @@
   } //</SailsIOClient>
 
 
+
+
+
+  //  ███████╗██╗  ██╗██████╗  ██████╗ ███████╗███████╗    ███████╗██████╗ ██╗  ██╗
+  //  ██╔════╝╚██╗██╔╝██╔══██╗██╔═══██╗██╔════╝██╔════╝    ██╔════╝██╔══██╗██║ ██╔╝
+  //  █████╗   ╚███╔╝ ██████╔╝██║   ██║███████╗█████╗      ███████╗██║  ██║█████╔╝
+  //  ██╔══╝   ██╔██╗ ██╔═══╝ ██║   ██║╚════██║██╔══╝      ╚════██║██║  ██║██╔═██╗
+  //  ███████╗██╔╝ ██╗██║     ╚██████╔╝███████║███████╗    ███████║██████╔╝██║  ██╗
+  //  ╚══════╝╚═╝  ╚═╝╚═╝      ╚═════╝ ╚══════╝╚══════╝    ╚══════╝╚═════╝ ╚═╝  ╚═╝
+  //
+
+
   // Add CommonJS support to allow this client SDK to be used from Node.js.
   if (typeof module === 'object' && typeof module.exports !== 'undefined') {
     module.exports = SailsIOClient;
-    return SailsIOClient;
   }
   // Add AMD support, registering this client SDK as an anonymous module.
   else if (typeof define === 'function' && define.amd) {
@@ -1313,10 +1425,13 @@
     });
   }
   else {
-    // Otherwise, try to instantiate the client:
-    // In case you're wrapping the socket.io client to prevent pollution of the
-    // global namespace, you can replace the global `io` with your own `io` here:
-    return SailsIOClient();
+    // Otherwise, try to instantiate the client using the global `io`:
+    SailsIOClient();
+
+    // Note:
+    // If you are modifying this file manually to wrap an existing socket.io client
+    // (e.g. to prevent pollution of the global namespace), you can replace the global
+    // `io` with your own `io` instance above.
   }
 
 })();

--- a/sails.io.js
+++ b/sails.io.js
@@ -312,19 +312,24 @@
   function SailsIOClient(_providedSocketIO) {
 
     // First, determine which `io` we're augmenting.
+    //
+    // Prefer the passed-in `io` instance, but fall back to the
+    // global one if we've got it.
     var io;
-
-    // Prefer the passed-in `io` instance, but fall back to the global one if we've got it.
-    if (!_providedSocketIO) {
+    if (_providedSocketIO) {
+      io = _providedSocketIO;
+    }
+    else {
       io = _existingGlobalSocketIO;
     }
+    // (note that for readability, we deliberately do not short circuit or use the tertiary operator above)
 
 
     // If a socket.io client (`io`) is not available, none of this will work.
     if (!io) {
       // If node:
       if (SDK_INFO.platform === 'node') {
-        throw new Error('No socket.io client available.  When requiring `sails.io.js` from Node.js, a socket.io client (`io`) must be passed in.  For example:\n```\nvar io = require(\'sails.io.js\')( require(\'socket.io-client\') )\n```\n(see https://github.com/balderdashy/sails.io.js/tree/master/test for examples)');
+        throw new Error('No socket.io client available.  When requiring `sails.io.js` from Node.js, a socket.io client (`io`) must be passed in; e.g.:\n```\nvar io = require(\'sails.io.js\')( require(\'socket.io-client\') )\n```\n(see https://github.com/balderdashy/sails.io.js/tree/master/test for more examples)');
       }
       // Otherwise, this is a web browser:
       else {

--- a/sails.io.js
+++ b/sails.io.js
@@ -24,23 +24,35 @@
 
 (function() {
 
-  // Save the URL that this script was fetched from for use below.
+  // Save the URL that this script was fetched from, and any other config provided
+  // as HTML attributes on the script tag.  This is used below.
   // (skip this if this SDK is being used outside of the DOM, i.e. in a Node process)
-  var urlThisScriptWasFetchedFrom = (function() {
+  var thisScriptTag = (function() {
     if (
       typeof window !== 'object' ||
       typeof window.document !== 'object' ||
       typeof window.document.getElementsByTagName !== 'function'
     ) {
-      return '';
+      return null;
     }
 
     // Return the URL of the last script loaded (i.e. this one)
     // (this must run before nextTick; see http://stackoverflow.com/a/2976714/486547)
     var allScriptsCurrentlyInDOM = window.document.getElementsByTagName('script');
-    var thisScript = allScriptsCurrentlyInDOM[allScriptsCurrentlyInDOM.length - 1];
-    return thisScript.src;
+    return allScriptsCurrentlyInDOM[allScriptsCurrentlyInDOM.length - 1];
   })();
+  
+  // If available, parse client-side sails.io.js configuration from the script tag,
+  // as well as grabbing hold of the URL from whence it was fetched.
+  var urlThisScriptWasFetchedFrom = '';
+  var scriptTagConfig = {};
+  if (thisScriptTag) {
+    urlThisScriptWasFetchedFrom = thisScriptTag.src;
+    // Now parse client-side configuration from the script tag.
+    scriptTagConfig.headers = thisScriptTag.getAttribute('headers');
+    // TODO: actually finish implementing this-- still a lot to figure out
+  }
+  
 
   // Constants
   var CONNECTION_METADATA_PARAMS = {

--- a/sails.io.js
+++ b/sails.io.js
@@ -462,7 +462,7 @@
             // If socket is attempting to reconnect, stop it.
             if (self._raw && self._raw.io && self._raw.io.reconnecting && !self._raw.io.skipReconnect) {
               self._raw.io.skipReconnect = true;
-              consolog("Stopping reconnect; use .reconnect() to connect socket after changing options.");
+              consolog('Stopping reconnect; use .reconnect() to connect socket after changing options.');
             }
             _opts[option] = value;
           }
@@ -520,7 +520,7 @@
       self.extraHeaders = self.initialConnectionHeaders || {};
 
       if (!(typeof module === 'object' && typeof module.exports !== 'undefined') && self.initialConnectionHeaders) {
-        console.warn("initialConnectionHeaders option available in Node.js only!");
+        console.warn('initialConnectionHeaders option available in Node.js only!');
       }
 
       // Ensure URL has no trailing slash

--- a/sails.io.js
+++ b/sails.io.js
@@ -48,10 +48,45 @@
   var scriptTagConfig = {};
   if (thisScriptTag) {
     urlThisScriptWasFetchedFrom = thisScriptTag.src;
-    // Now parse client-side configuration from the script tag.
-    scriptTagConfig.headers = thisScriptTag.getAttribute('headers');
-    // TODO: actually finish implementing this-- still a lot to figure out
+    
+    // Now parse the most common client-side configuration settings from the script tag. (experimental)
+    // ------------------------------------------------------------
+    // autoConnect | ((boolean))    | `true`
+    // environment | ((string))     | `'development'`
+    // headers     | ((dictionary)) | `{}`
+    // ------------------------------------------------------------
+    // Note that `null` returned from getAttribute() means that the HTML attribute
+    // was not specified, so we treat it as undefined.
+    scriptTagConfig.autoConnect = (function (htmlAttrVal){
+      if (typeof htmlAttrVal === 'string') {
+        try { htmlAttrVal = JSON.parse(htmlAttrVal); } catch (e) { }
+      }
+    })(thisScriptTag.getAttribute('autoConnect'));
+    if (scriptTagConfig.autoConnect === null){ delete scriptTagConfig.autoConnect; }
+    
+    // scriptTagConfig.environment = thisScriptTag.getAttribute('environment');
+    // if (scriptTagConfig.environment === null){ delete scriptTagConfig.environment; }
+    // TODO
+    
+    // scriptTagConfig.headers = thisScriptTag.getAttribute('headers');
+    // if (scriptTagConfig.headers === null){ delete scriptTagConfig.headers; }
+    // TODO
+    
+    
+    // NOT CURRENTLY SUPPORTED:
+    // ------------------------------------------------------------
+    // url         | ((string))     | _In browser, the URL of the page that loaded the sails.io.js script. In Node.js, no default._
+    // transports  | ((array))      | `['polling', 'websocket']`
+    //
+    // useCORSRouteToGetCookie | ((boolean)) | `true`
+    // query       | ((string))     | `''` 
+    // initialConnectionHeaders  | ((dictionary)) | `{}`
+    // ------------------------------------------------------------
+    
   }
+  console.log('urlThisScriptWasFetchedFrom', urlThisScriptWasFetchedFrom);
+  console.log('scriptTagConfig', scriptTagConfig);
+  
   
 
   // Constants

--- a/sails.io.js
+++ b/sails.io.js
@@ -150,19 +150,17 @@
     }
 
 
-    // NOT CURRENTLY SUPPORTED:
-    // ------------------------------------------------------------
+    // OTHER `io.sails` OPTIONS NOT CURRENTLY SUPPORTED VIA HTML ATTRIBUTES:
+    // --------------------------------------------------------------------------------
     // url         | ((string))     | _In browser, the URL of the page that loaded the sails.io.js script. In Node.js, no default._
     // transports  | ((array))      | `['polling', 'websocket']`
     //
     // useCORSRouteToGetCookie | ((boolean)) | `true`
     // query       | ((string))     | `''`
     // initialConnectionHeaders  | ((dictionary)) | `{}`
-    // ------------------------------------------------------------
+    // --------------------------------------------------------------------------------
 
   }
-  console.log('urlThisScriptWasFetchedFrom', urlThisScriptWasFetchedFrom);
-  console.log('scriptTagConfig', scriptTagConfig);
 
 
 
@@ -1170,7 +1168,6 @@
         io.sails[htmlAttrName] = scriptTagConfig[htmlAttrName];
       }
     });
-    console.log('io.sails', io.sails);
 
 
 

--- a/sails.io.js
+++ b/sails.io.js
@@ -25,6 +25,15 @@
 (function() {
 
 
+  //   ██████╗ ██████╗ ███╗   ██╗███████╗████████╗ █████╗ ███╗   ██╗████████╗███████╗
+  //  ██╔════╝██╔═══██╗████╗  ██║██╔════╝╚══██╔══╝██╔══██╗████╗  ██║╚══██╔══╝██╔════╝
+  //  ██║     ██║   ██║██╔██╗ ██║███████╗   ██║   ███████║██╔██╗ ██║   ██║   ███████╗
+  //  ██║     ██║   ██║██║╚██╗██║╚════██║   ██║   ██╔══██║██║╚██╗██║   ██║   ╚════██║
+  //  ╚██████╗╚██████╔╝██║ ╚████║███████║   ██║   ██║  ██║██║ ╚████║   ██║   ███████║
+  //   ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝   ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═══╝   ╚═╝   ╚══════╝
+  //
+
+
   /**
    * Constant containing the names of all available options
    * for individual sockets.
@@ -55,12 +64,72 @@
    * loaded this file.
    *
    * @type {Array}
+   *
+   * (this is unused if loading from node.js)
    */
   var CONFIGURABLE_VIA_HTML_ATTR = [
     'autoConnect',
     'environment',
     'headers'
   ];
+
+
+
+
+  /**
+   * Constant containing the names of querystring
+   * parameters sent when connecting any SailsSocket.
+   *
+   * @type {Dictionary}
+   */
+  var CONNECTION_METADATA_PARAMS = {
+    version: '__sails_io_sdk_version',
+    platform: '__sails_io_sdk_platform',
+    language: '__sails_io_sdk_language'
+  };
+
+
+  /**
+   * Constant containing metadata about the platform, language, and
+   * current version of this SDK.
+   *
+   * @type {Dictionary}
+   */
+  var SDK_INFO = {
+    version: '0.13.5', // <-- pulled automatically from package.json, do not change!
+    platform: typeof module === 'undefined' ? 'browser' : 'node',
+    language: 'javascript'
+  };
+  SDK_INFO.versionString =
+    CONNECTION_METADATA_PARAMS.version + '=' + SDK_INFO.version + '&' +
+    CONNECTION_METADATA_PARAMS.platform + '=' + SDK_INFO.platform + '&' +
+    CONNECTION_METADATA_PARAMS.language + '=' + SDK_INFO.language;
+
+
+
+
+
+  //   ██████╗ ██████╗  █████╗ ██████╗     ██╗ ██████╗    ███████╗ █████╗ ██╗██╗     ███████╗
+  //  ██╔════╝ ██╔══██╗██╔══██╗██╔══██╗    ██║██╔═══██╗   ██╔════╝██╔══██╗██║██║     ██╔════╝ ▄ ██╗▄
+  //  ██║  ███╗██████╔╝███████║██████╔╝    ██║██║   ██║   ███████╗███████║██║██║     ███████╗  ████╗
+  //  ██║   ██║██╔══██╗██╔══██║██╔══██╗    ██║██║   ██║   ╚════██║██╔══██║██║██║     ╚════██║ ▀╚██╔▀
+  //  ╚██████╔╝██║  ██║██║  ██║██████╔╝    ██║╚██████╔╝██╗███████║██║  ██║██║███████╗███████║██╗╚═╝
+  //   ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝     ╚═╝ ╚═════╝ ╚═╝╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚═╝
+  //
+  //  ███████╗██████╗  ██████╗ ███╗   ███╗      ██╗███████╗ ██████╗██████╗ ██╗██████╗ ████████╗██╗
+  //  ██╔════╝██╔══██╗██╔═══██╗████╗ ████║     ██╔╝██╔════╝██╔════╝██╔══██╗██║██╔══██╗╚══██╔══╝╚██╗
+  //  █████╗  ██████╔╝██║   ██║██╔████╔██║    ██╔╝ ███████╗██║     ██████╔╝██║██████╔╝   ██║    ╚██╗
+  //  ██╔══╝  ██╔══██╗██║   ██║██║╚██╔╝██║    ╚██╗ ╚════██║██║     ██╔══██╗██║██╔═══╝    ██║    ██╔╝
+  //  ██║     ██║  ██║╚██████╔╝██║ ╚═╝ ██║     ╚██╗███████║╚██████╗██║  ██║██║██║        ██║   ██╔╝
+  //  ╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═╝     ╚═╝      ╚═╝╚══════╝ ╚═════╝╚═╝  ╚═╝╚═╝╚═╝        ╚═╝   ╚═╝
+  //
+  //  ██╗  ██╗████████╗███╗   ███╗██╗          █████╗ ████████╗████████╗██████╗ ███████╗
+  //  ██║  ██║╚══██╔══╝████╗ ████║██║         ██╔══██╗╚══██╔══╝╚══██╔══╝██╔══██╗██╔════╝
+  //  ███████║   ██║   ██╔████╔██║██║         ███████║   ██║      ██║   ██████╔╝███████╗
+  //  ██╔══██║   ██║   ██║╚██╔╝██║██║         ██╔══██║   ██║      ██║   ██╔══██╗╚════██║
+  //  ██║  ██║   ██║   ██║ ╚═╝ ██║███████╗    ██║  ██║   ██║      ██║   ██║  ██║███████║
+  //  ╚═╝  ╚═╝   ╚═╝   ╚═╝     ╚═╝╚══════╝    ╚═╝  ╚═╝   ╚═╝      ╚═╝   ╚═╝  ╚═╝╚══════╝
+  //
 
 
   // Save the URL that this script was fetched from, and any other config provided
@@ -159,35 +228,14 @@
     // query       | ((string))     | `''`
     // initialConnectionHeaders  | ((dictionary)) | `{}`
     // --------------------------------------------------------------------------------
-
   }
 
-
-
-  // Constants
-  var CONNECTION_METADATA_PARAMS = {
-    version: '__sails_io_sdk_version',
-    platform: '__sails_io_sdk_platform',
-    language: '__sails_io_sdk_language'
-  };
-
-  // Current version of this SDK (sailsDK?!?!) and other metadata
-  // that will be sent along w/ the initial connection request.
-  var SDK_INFO = {
-    version: '0.13.5', // <-- pulled automatically from package.json, do not change!
-    platform: typeof module === 'undefined' ? 'browser' : 'node',
-    language: 'javascript'
-  };
-  SDK_INFO.versionString =
-    CONNECTION_METADATA_PARAMS.version + '=' + SDK_INFO.version + '&' +
-    CONNECTION_METADATA_PARAMS.platform + '=' + SDK_INFO.platform + '&' +
-    CONNECTION_METADATA_PARAMS.language + '=' + SDK_INFO.language;
 
 
   // In case you're wrapping the socket.io client to prevent pollution of the
   // global namespace, you can pass in your own `io` to replace the global one.
   // But we still grab access to the global one if it's available here:
-  var _io = (typeof io !== 'undefined') ? io : null;
+  var _existingGlobalSocketIO = (typeof io !== 'undefined') ? io : null;
 
   /**
    * Augment the `io` object passed in with methods for talking and listening
@@ -202,12 +250,21 @@
 
     // Prefer the passed-in `io` instance, but fall back to the global one if we've got it.
     if (!io) {
-      io = _io;
+      io = _existingGlobalSocketIO;
     }
 
 
     // If the socket.io client is not available, none of this will work.
-    if (!io) throw new Error('`sails.io.js` requires a socket.io client, but `io` was not passed in or available as a global.');
+    if (!io) {
+      // If node:
+      if (typeof module === 'object' && typeof module.exports !== 'undefined') {
+        throw new Error('No socket.io client available.  When requiring `sails.io.js` from Node.js, a socket.io client (`io`) must be passed in.  For example:\n```\nvar io = require(\'sails.io.js\')( require(\'socket.io-client\') )\n```\n(see https://github.com/balderdashy/sails.io.js/tree/master/test for examples)');
+      }
+      // If browser:
+      else {
+        throw new Error('The Sails socket SDK depends on the socket.io client, but the socket.io global (`io`) was not available when `sails.io.js` loaded.  Normally, the socket.io client code is bundled with sails.io.js, so something is a little off.  Please check to be sure this version of `sails.io.js` has the minified Socket.io client at the top of the file.');
+      }
+    }
 
 
 
@@ -1241,7 +1298,7 @@
 
     // Return the `io` object.
     return io;
-  }
+  } //</SailsIOClient>
 
 
   // Add CommonJS support to allow this client SDK to be used from Node.js.


### PR DESCRIPTION
Instead of:

```html
<script src="/js/dependencies/sails.io.js"></script>
<script type="text/javascript">
  io.sails.headers = {
    'x-csrf-token': <%- typeof _csrf !== 'undefined' ? JSON.stringify(_csrf) : 'null' %>
  };
</script>
```


You can do:
```
<script src="/js/dependencies/sails.io.js" headers='{"x-csrf-token":<%- typeof _csrf !== 'undefined' ? JSON.stringify(_csrf) : 'null' %>}'></script>
```
(allowing you to avoid tricky issues with script tag order, as well as avoiding the inline code)



Currently supports `autoConnect`, `environment`, and `headers`.


========================

Before bringing this in, we need to:
- test this more
- update socket client reference docs
- do a search in sails-docs for anywhere else mentioning io.sails and make sure this is mentioned
