### PR TITLE
`sails-disk` missing from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mocha": "~1.18.0",
     "phantomjs-prebuilt": "^2.1.4",
     "sails": "balderdashy/sails",
+    "sails-disk": "^0.10.9",
     "socket.io-client": "~1.4.0"
   },
   "scripts": {


### PR DESCRIPTION
The module would fail to install or run tests without this dependency.  I'm not sure if it was on purpose, but I figured a pull request that solved the issue was better than another issue to deal with.

Here's the error:
```
➜  sails.io.js git:(master) npm link
npm WARN deprecated lodash@0.9.2: Grunt needs your help! See https://github.com/gruntjs/grunt/issues/1403.
npm WARN deprecated graceful-fs@1.2.3: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
npm WARN deprecated lodash@1.0.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated graceful-fs@2.0.3: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
 
> sails@0.12.1 preinstall /home/geagon/Projects/sails.io.js/node_modules/sails
> node ./lib/preinstall_npmcheck.js

Sails.js Installation: Checking npm-version successful
 
> phantomjs-prebuilt@2.1.6 install /home/geagon/Projects/sails.io.js/node_modules/phantomjs-prebuilt
> node install.js

PhantomJS not found on PATH
Downloading https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
Saving to /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
Receiving...
- [=====================================---] 92%|
Received 22866K total.
Extracting tar contents (via spawned process)
Removing /home/geagon/Projects/sails.io.js/node_modules/phantomjs-prebuilt/lib/phantom
Copying extracted folder /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2-extract-1458659085563/phantomjs-2.1.1-linux-x86_64 -> /home/geagon/Projects/sails.io.js/node_modules/phantomjs-prebuilt/lib/phantom
Writing location.js file
Done. Phantomjs binary available at /home/geagon/Projects/sails.io.js/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs
npm WARN deprecated lodash@2.4.1: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated native-or-bluebird@1.1.2: 'native-or-bluebird' is deprecated. Please use 'any-promise' instead.
npm WARN deprecated grunt-lib-contrib@0.7.1: DEPRECATED. See readme: https://github.com/gruntjs/grunt-lib-contrib
npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
\
> sails.io.js@0.13.6 prepublish /home/geagon/Projects/sails.io.js
> ./node_modules/grunt-cli/bin/grunt publish && npm test

Running "replace:main" (replace) task

Running "replace:sioClient" (replace) task

Running "uglify:main" (uglify) task
>> 1 file created.

Running "concat:header" (concat) task
File "./.tmp/header.txt" created.

Running "concat:main" (concat) task
File "./dist/sails.io.js" created.

Running "replace:dist" (replace) task

Running "clean:main" (clean) task
>> 2 paths cleaned.

Done, without errors.

> sails.io.js@0.13.6 test /home/geagon/Projects/sails.io.js
> node ./node_modules/mocha/bin/mocha -b --reporter spec --timeout 10000

(node) child_process: options.customFds option is deprecated. Use options.stdio instead.


  io.socket
    With default settings
error: A hook (`orm`) failed to load!
      1) "before all" hook

  0 passing (709ms)
  1 failing

  1) io.socket With default settings "before all" hook:
     Error: Trying to use an unrecognized adapter, `sails-disk, in datastore `localDiskDb`.
This may or may not be a real adapter available on NPM, but in any case it looks like `sails-disk` is not installed in this app                                                                               
(at least it is not in the expected path within the local `node_modules/` directory).                  

To attempt to install this adapter, run:                                                               
`npm install sails-disk --save                                                                         
      at constructError (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/sails-hook-orm/lib/construct-error.js:57:13)                                                                       
      at loadAdapterFromAppDependencies (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/sails-hook-orm/lib/load-adapter-from-app-dependencies.js:59:13)                                    
      at _eachRelevantDatastoreIdentity (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/sails-hook-orm/lib/initialize.js:123:56)                                                           
      at arrayEach (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/lodash/index.js:1289:13)                                                                                                
      at Function.<anonymous> (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/lodash/index.js:3345:13)                                                                                     
      at Array.async.auto._attemptToLoadUnrecognizedAdapters (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/sails-hook-orm/lib/initialize.js:112:11)                                      
      at listener (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/sails-hook-orm/node_modules/async/lib/async.js:605:42)                                                                   
      at /home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/sails-hook-orm/node_modules/async/lib/async.js:544:17                                                                              
      at _arrayEach (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/sails-hook-orm/node_modules/async/lib/async.js:85:13)                                                                  
      at Immediate.taskComplete (/home/geagon/Projects/sails.io.js/node_modules/sails/node_modules/sails-hook-orm/node_modules/async/lib/async.js:543:13)                                                     
      at processImmediate [as _immediateCallback] (timers.js:383:17)                                   



npm ERR! Test failed.  See above for more details.

npm ERR! Linux 3.19.0-32-generic
npm ERR! argv "/home/geagon/.nvm/versions/node/v4.3.1/bin/node" "/home/geagon/.nvm/versions/node/v4.3.1/bin/npm" "link"
npm ERR! node v4.3.1
npm ERR! npm  v2.14.12
npm ERR! code ELIFECYCLE
npm ERR! sails.io.js@0.13.6 prepublish: `./node_modules/grunt-cli/bin/grunt publish && npm test`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the sails.io.js@0.13.6 prepublish script './node_modules/grunt-cli/bin/grunt publish && npm test'.
npm ERR! This is most likely a problem with the sails.io.js package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     ./node_modules/grunt-cli/bin/grunt publish && npm test
npm ERR! You can get their info via:
npm ERR!     npm owner ls sails.io.js
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/geagon/Projects/sails.io.js/npm-debug.log
➜  sails.io.js git:(master) ✗ rm -rf node_modules 
➜  sails.io.js git:(master) ✗ git checkout ec8be
error: Your local changes to the following files would be overwritten by checkout:
        dist/sails.io.js
Please, commit your changes or stash them before you can switch branches.
Aborting
```