### PR TITLE
Update request lib to 2.72.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "request": "~2.34.0"
+    "request": "~2.72.0"
   },
   "devDependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
Older versions of `request` cause problems when bundling with `webpack` like:

```
WARNING in ./~/sails.io.js/~/request/lib/optional.js
Critical dependencies:
3:11-34 the request of a dependency is an expression
 @ ./~/sails.io.js/~/request/lib/optional.js 3:11-34
```

These issues have been fixed in 2.72.0.