### PR TITLE
Fixing commit 8393d87

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -531,20 +531,17 @@
     function JWR(responseCtx) {
       this.body = responseCtx.body || {};
       this.headers = responseCtx.headers || {};
-      this.statusCode = responseCtx.statusCode || 200;
-   
+      this.statusCode = (typeof responseCtx.statusCode === 'undefined') ? 200 : responseCtx.statusCode;
+
       if (this.statusCode < 200 || this.statusCode >= 400) {
         // Determine the appropriate error message.
-        var msg = 'Server responded with a ' + this.statusCode + ' status code';
-
-        if (typeof this.body === 'string') {
-          msg += ':\n```\n' + this.body + '\n```';
-        }
-        else if (typeof this.body.message === 'string') {
-          msg += ':\n```\n' + this.body.message + '\n```';
+        var msg;
+        if (this.statusCode === 0) {
+          msg = 'The socket request failed.';
         }
         else {
-          msg += '.';
+          msg = 'Server responded with a ' + this.statusCode + ' status code';
+          msg += ':\n```\n' + JSON.stringify(this.body, null, 2) + '\n```';
         }
 
         // Now build and attach Error instance.

--- a/sails.io.js
+++ b/sails.io.js
@@ -532,21 +532,19 @@
       this.body = responseCtx.body || {};
       this.headers = responseCtx.headers || {};
       this.statusCode = responseCtx.statusCode || 200;
+   
       if (this.statusCode < 200 || this.statusCode >= 400) {
-
         // Determine the appropriate error message.
-        var msg;
-        if (this.statusCode === 0) {
-          msg = 'Server responded with a '+this.statusCode+' status code';
-          if (this.body !== undefined && this.body !== null) {
-            msg += ':\n```\n'+this.body+'\n```';
-          }
-          else {
-            msg += '.';
-          }
+        var msg = 'Server responded with a ' + this.statusCode + ' status code';
+
+        if (typeof this.body === 'string') {
+          msg += ':\n```\n' + this.body + '\n```';
+        }
+        else if (typeof this.body.message === 'string') {
+          msg += ':\n```\n' + this.body.message + '\n```';
         }
         else {
-          msg = 'The socket request failed.';
+          msg += '.';
         }
 
         // Now build and attach Error instance.


### PR DESCRIPTION
On commit 8393d87, condition `(this.statusCode === 0)` line 539 will always be false as `this.statusCode` is set to 200 by default. Same for `this.body` line 541 that is an empty object by default. Then the error message was always set to `'The socket request failed.'`.

Following code set a more explicit message.