### PR TITLE
Changed socket header in README instructions for CSRF.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Set a `x-csrf-token` header to be sent with every request made using `io.socket.
 ```html
 <script type="text/javascript" src="/dependencies/sails.io.js"></script>
 <script type="text/javascript">
-io.sails.headers = {
+io.socket.headers = {
   "x-csrf-token": someToken,
 };
 // This POST request will now include the x-csrf-token header


### PR DESCRIPTION
Script says that websocket request headers are within io.sails.headers, however this would not apply for me, so i set io.socket.headers.

<!-- ORIGINAL -->
<script type="text/javascript">
io.sails.headers = {
  "x-csrf-token": someToken,
};
// This POST request will now include the x-csrf-token header
io.socket.post("/foo", someData, someCallback);
</script>