### PR TITLE
Handle disconnects gracefully

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails.io.js-dist",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "description": "Distribution version of sails.io.js for browsers, including bundled socket.io-client.",
   "main": "sails.io.js",
   "repository": {

--- a/dist/sails.io.js
+++ b/dist/sails.io.js
@@ -968,7 +968,11 @@ return new(b[["Active"].concat("Object").join("X")])("Microsoft.XMLHTTP")}catch(
           // and then wipe the list.
           if (typeof self.responseCbs === 'object' && self.responseCbs.length) {
             self.responseCbs.forEach(function(responseCb) {
-              responseCb(new Error('The socket disconnected before the request completed.'));
+              responseCb(new Error('The socket disconnected before the request completed.'), {
+                body: null,
+                statusCode: 0,
+                headers: {}
+              });
             });
             self.responseCbs = [];
           }

--- a/dist/sails.io.js
+++ b/dist/sails.io.js
@@ -630,9 +630,9 @@ return new(b[["Active"].concat("Object").join("X")])("Microsoft.XMLHTTP")}catch(
           // Set flag indicating that callback was called, to avoid duplicate calls.
           requestCtx.calledCb = true;
           // Remove the callback from the list.
-          socket.responseCbs.splice(socket.responseCbs.indexOf(cb), 1);
+          socket._responseCbs.splice(socket._responseCbs.indexOf(cb), 1);
           // Remove the context from the list.
-          socket.requestCtxs.splice(socket.requestCtxs.indexOf(requestCtx), 1);
+          socket._requestCtxs.splice(socket._requestCtxs.indexOf(requestCtx), 1);
         }
       });
     }
@@ -963,27 +963,38 @@ return new(b[["Active"].concat("Object").join("X")])("Microsoft.XMLHTTP")}catch(
         });
 
         self.on('disconnect', function() {
+
+          // Get a timestamp of when the disconnect was detected.
           self.connectionLostTimestamp = (new Date()).getTime();
-          // If there is a list of registered callbacks, call each of them with an error
-          // and then wipe the list.
-          if (typeof self.responseCbs === 'object' && self.responseCbs.length) {
-            self.responseCbs.forEach(function(responseCb) {
+
+          // Get a shallow clone of the internal array of response callbacks, in case any of the callbacks mutate it.
+          var responseCbs = [].concat(self._responseCbs || []);
+          // Wipe the internal array of response callbacks before executing them, in case a callback happens to add
+          // a new request to the queue.
+          self._responseCbs = [];
+
+          // Do the same for the internal request context list.
+          var requestCtxs = [].concat(self._requestCtxs || []);
+          self._requestCtxs = [];
+
+          // Loop through the callbacks for all in-progress requests, and call them each with an error indicating the disconnect.
+          if (responseCbs.length) {
+            responseCbs.forEach(function(responseCb) {
               responseCb(new Error('The socket disconnected before the request completed.'), {
                 body: null,
                 statusCode: 0,
                 headers: {}
               });
             });
-            self.responseCbs = [];
           }
-          // If there is a list of request context, indicate that their callbacks have been
+
+          // If there is a list of request contexts, indicate that their callbacks have been
           // called and then wipe the list.  This prevents errors in the edge case of a response
           // somehow coming back after the socket reconnects.
-          if (typeof self.requestCtxs === 'object' && self.requestCtxs.length) {
-            self.requestCtxs.forEach(function(requestCtx) {
+          if (requestCtxs.length) {
+            requestCtxs.forEach(function(requestCtx) {
               requestCtx.calledCb = true;
             });
-            self.requestCtxs = [];
           }
 
           consolog('====================================');
@@ -1456,19 +1467,19 @@ return new(b[["Active"].concat("Object").join("X")])("Microsoft.XMLHTTP")}catch(
       };
 
       // Get a reference to the callback list, or create a new one.
-      this.responseCbs = this.responseCbs || [];
+      this._responseCbs = this._responseCbs || [];
 
       // Get a reference to the request context list, or create a new one.
-      this.requestCtxs = this.requestCtxs || [];
+      this._requestCtxs = this._requestCtxs || [];
 
       // Add this callback to the list.  If the socket disconnects, we'll call
       // each cb in the list with an error and reset the list.  Otherwise the
       // cb will be removed from the list when the server responds.
-      this.responseCbs.push(cb);
+      this._responseCbs.push(cb);
 
       // Add the request context to the list.  It will be removed once the
       // response comes back, or if the socket disconnects.
-      this.requestCtxs.push(requestCtx);
+      this._requestCtxs.push(requestCtx);
 
       // Merge global headers in, if there are any.
       if (this.headers && 'object' === typeof this.headers) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails.io.js",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "description": "Javascript SDK for communicating w/ a Sails server via WebSockets/socket.io.",
   "main": "sails.io.js",
   "directories": {

--- a/sails.io.js
+++ b/sails.io.js
@@ -611,9 +611,9 @@
           // Set flag indicating that callback was called, to avoid duplicate calls.
           requestCtx.calledCb = true;
           // Remove the callback from the list.
-          socket.responseCbs.splice(socket.responseCbs.indexOf(cb), 1);
+          socket._responseCbs.splice(socket._responseCbs.indexOf(cb), 1);
           // Remove the context from the list.
-          socket.requestCtxs.splice(socket.requestCtxs.indexOf(requestCtx), 1);
+          socket._requestCtxs.splice(socket._requestCtxs.indexOf(requestCtx), 1);
         }
       });
     }
@@ -944,27 +944,38 @@
         });
 
         self.on('disconnect', function() {
+
+          // Get a timestamp of when the disconnect was detected.
           self.connectionLostTimestamp = (new Date()).getTime();
-          // If there is a list of registered callbacks, call each of them with an error
-          // and then wipe the list.
-          if (typeof self.responseCbs === 'object' && self.responseCbs.length) {
-            self.responseCbs.forEach(function(responseCb) {
+
+          // Get a shallow clone of the internal array of response callbacks, in case any of the callbacks mutate it.
+          var responseCbs = [].concat(self._responseCbs || []);
+          // Wipe the internal array of response callbacks before executing them, in case a callback happens to add
+          // a new request to the queue.
+          self._responseCbs = [];
+
+          // Do the same for the internal request context list.
+          var requestCtxs = [].concat(self._requestCtxs || []);
+          self._requestCtxs = [];
+
+          // Loop through the callbacks for all in-progress requests, and call them each with an error indicating the disconnect.
+          if (responseCbs.length) {
+            responseCbs.forEach(function(responseCb) {
               responseCb(new Error('The socket disconnected before the request completed.'), {
                 body: null,
                 statusCode: 0,
                 headers: {}
               });
             });
-            self.responseCbs = [];
           }
-          // If there is a list of request context, indicate that their callbacks have been
+
+          // If there is a list of request contexts, indicate that their callbacks have been
           // called and then wipe the list.  This prevents errors in the edge case of a response
           // somehow coming back after the socket reconnects.
-          if (typeof self.requestCtxs === 'object' && self.requestCtxs.length) {
-            self.requestCtxs.forEach(function(requestCtx) {
+          if (requestCtxs.length) {
+            requestCtxs.forEach(function(requestCtx) {
               requestCtx.calledCb = true;
             });
-            self.requestCtxs = [];
           }
 
           consolog('====================================');
@@ -1437,19 +1448,19 @@
       };
 
       // Get a reference to the callback list, or create a new one.
-      this.responseCbs = this.responseCbs || [];
+      this._responseCbs = this._responseCbs || [];
 
       // Get a reference to the request context list, or create a new one.
-      this.requestCtxs = this.requestCtxs || [];
+      this._requestCtxs = this._requestCtxs || [];
 
       // Add this callback to the list.  If the socket disconnects, we'll call
       // each cb in the list with an error and reset the list.  Otherwise the
       // cb will be removed from the list when the server responds.
-      this.responseCbs.push(cb);
+      this._responseCbs.push(cb);
 
       // Add the request context to the list.  It will be removed once the
       // response comes back, or if the socket disconnects.
-      this.requestCtxs.push(requestCtx);
+      this._requestCtxs.push(requestCtx);
 
       // Merge global headers in, if there are any.
       if (this.headers && 'object' === typeof this.headers) {

--- a/sails.io.js
+++ b/sails.io.js
@@ -119,7 +119,7 @@
    * @type {Dictionary}
    */
   var SDK_INFO = {
-    version: '1.1.13', // <-- pulled automatically from package.json, do not change!
+    version: '1.2.0', // <-- pulled automatically from package.json, do not change!
     language: 'javascript',
     platform: (function (){
       if (typeof module === 'object' && typeof module.exports !== 'undefined') {

--- a/sails.io.js
+++ b/sails.io.js
@@ -949,7 +949,11 @@
           // and then wipe the list.
           if (typeof self.responseCbs === 'object' && self.responseCbs.length) {
             self.responseCbs.forEach(function(responseCb) {
-              responseCb(new Error('The socket disconnected before the request completed.'));
+              responseCb(new Error('The socket disconnected before the request completed.'), {
+                body: null,
+                statusCode: 0,
+                headers: {}
+              });
             });
             self.responseCbs = [];
           }

--- a/test/disconnect.test.js
+++ b/test/disconnect.test.js
@@ -49,7 +49,11 @@ describe('On disconnect', function () {
           setTimeout( function() {
             io.socket.get('/ok?x=3', function (body, res) {
               assert(_.isError(body));
-              assert(_.isUndefined(res));
+              assert(res);
+              assert.equal(res.body, null);
+              assert.equal(res.statusCode, 0);
+              assert(_.isPlainObject(res.headers));
+              assert.equal(_.keys(res.headers).length, 0);
               return cb();
             });
           }, 300 )

--- a/test/disconnect.test.js
+++ b/test/disconnect.test.js
@@ -1,0 +1,68 @@
+/**
+ * Module dependencies
+ */
+
+var util = require('util');
+var assert = require('assert');
+var lifecycle = require('./helpers/lifecycle');
+var _setupRoutes = require('./helpers/setupRoutes');
+var request = require('request');
+var async = require('async');
+var _ = require('lodash');
+
+describe('On disconnect', function () {
+
+  before(function(done){
+    lifecycle.setup({
+      routes: {
+        '/ok': function (req, res) {
+          setTimeout(()=>{return res.send(req.param('x'));}, 100);
+        },
+      }
+    }, done)
+  });
+
+  after(lifecycle.teardown);
+
+  it('should call callbacks for in-progress requests with an error', function (done) {
+    // console.log('connecting...');
+    io.socket.on('connect', function (){
+
+      async.auto({
+        r1: function(cb) {
+          setTimeout( function() {
+            io.socket.get('/ok?x=1', function (body, res) {
+              assert.equal(body, '1');
+              return cb();
+            });
+          }, 100 )
+        },
+        r2: function(cb) {
+          setTimeout( function() {
+            io.socket.get('/ok?x=2', function (body, res) {
+              assert.equal(body, '2');
+              return cb();
+            });
+          }, 200 )
+        },
+        r3: function(cb) {
+          setTimeout( function() {
+            io.socket.get('/ok?x=3', function (body, res) {
+              assert(_.isError(body));
+              assert(_.isUndefined(res));
+              return cb();
+            });
+          }, 300 )
+        },
+        kill: function(cb) {
+          setTimeout( function() {
+            io.socket.disconnect();
+            return cb();
+          }, 400 )
+        },
+      }, done);
+
+    });
+
+  });
+});

--- a/test/helpers/lifecycle.js
+++ b/test/helpers/lifecycle.js
@@ -55,12 +55,12 @@ module.exports = {
         grunt: false,
         sockets: SHSockets
       },
-      routes: {
+      routes: _.extend({
         '/sails.io.js': function(req, res) {
           res.header('Content-type', 'application/javascript');
           require('fs').createReadStream(require('path').resolve(__dirname, '..', '..', 'dist', 'sails.io.js')).pipe(res);
         }
-      }
+      }, opts.routes || {})
     },function (err) {
       if (err) { return cb(err); }
       // console.log('lifted');


### PR DESCRIPTION
Maintains a list of request callbacks (to be called w/ an error in case of disconnect), and a list of request contexts (to mark them as having called their callbacks when relevant, to avoid double-calls)