### PR TITLE
fixed socket.io-client v4 not being able to obtain options from sails

### DIFF
--- a/sails.io.js
+++ b/sails.io.js
@@ -668,6 +668,7 @@
         // Okay to change global headers while socket is connected
         if (option == 'headers') {return;}
         Object.defineProperty(self, option, {
+          enumerable: true,
           get: function() {
             if (option == 'url') {
               return _opts[option] || (self._raw && self._raw.io && self._raw.io.uri);


### PR DESCRIPTION
socket.io-client v4 uses `_opts = Object.assign({}, opts)`, hence it cannot obtain options from sails.io.js that were defined using getters/setters through `Object.defineProperty` without explicitly marking those properties as enumerable.